### PR TITLE
Trigger 'fullscreenchange' event when state is updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The fullscreen service is injected into all controllers, components and routes. 
 
 - `.on('error', ...)` - Fullscreen service includes [Ember.Evented](http://emberjs.com/api/classes/Ember.Evented.html) mixin. When a fullscreen request fails, ember-fullscreen triggers an `error` event.
 
+- `.on('fullscreenChange', ...)` - When the fullscreen state changes, ember-fullscreen notifies the new `isEnabled` state.
+
 ## Examples
 
 Create a button in your controller with an action that toggles fullscreen mode:

--- a/addon/services/fullscreen.js
+++ b/addon/services/fullscreen.js
@@ -31,7 +31,10 @@ export default Ember.Service.extend(Ember.Evented, {
   }),
 
   updateEnabled() {
-    this.set('isEnabled', this.screenfull.isFullscreen);
+    let isFullscreenEnabled = this.screenfull.isFullscreen;
+
+    this.set('isEnabled', isFullscreenEnabled);
+    this.trigger('fullscreenChange', isFullscreenEnabled);
   },
 
   onError(event) {


### PR DESCRIPTION
There was no way to be notified when the state was changing from fullscreen `enabled` to `disabled`. With this change, we will now be able to subscribe to a `fullscreenchange` event to be notified with the new state when it changes.