### PR TITLE
Bump screenfull version to 3.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "ember-cli-node-assets": "^0.2.2",
     "fastboot-transform": "^0.1.2",
-    "screenfull": "^3.3.1",
+    "screenfull": "^3.3.3",
     "ember-cli-babel": "^6.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes Chrome error when toggling fullscreen on version 67+;

More info on:  https://github.com/sindresorhus/screenfull.js/commit/04f9ec43ef810f84870b1bb72e005aab85b1bf58